### PR TITLE
Add portage package set 2020

### DIFF
--- a/etc/portage/sets/2020
+++ b/etc/portage/sets/2020
@@ -1,0 +1,3 @@
+dev-lang/tcl
+dev-lang/lua
+app-admin/Lmod


### PR DESCRIPTION
Define a package set for the 2020 prefix

Use to merge the compatibility stack:
`emerge --ask @2020`

[wiki.gentoo.org/wiki//etc/portage/sets](https://wiki.gentoo.org/wiki//etc/portage/sets)