### PR TITLE
Fix typo in 2020.10 set

### DIFF
--- a/etc/portage/sets/2020.10
+++ b/etc/portage/sets/2020.10
@@ -1,6 +1,6 @@
 app-admin/Lmod
 app-editors/emacs
-app-editor/vim
+app-editors/vim
 dev-util/strace
 sys-apps/archspec
 sys-cluster/rdma-core


### PR DESCRIPTION
Oops, just found a typo (`app-editor` instead of `app-editors`)...