### PR TITLE
Add fonts to 2020.10 set

### DIFF
--- a/etc/portage/sets/2020.10
+++ b/etc/portage/sets/2020.10
@@ -2,6 +2,8 @@ app-admin/Lmod
 app-editors/emacs
 app-editor/vim
 dev-util/strace
+media-fonts/dejavu
+media-fonts/liberation-fonts
 sys-apps/archspec
 sys-cluster/rdma-core
 sys-fabric/opa-psm2


### PR DESCRIPTION
This adds the Liberation fonts collection, which is [the Gentoo Fonts team recommendation for the default latin fonts](https://wiki.gentoo.org/wiki/Fontconfig#Picking_fonts), and the Dejavu fonts [that ParaView needs](https://www.cfd-online.com/Forums/openfoam-installation/173514-paraview-4-4-font-problem.html).

cfr. https://github.com/EESSI/software-layer/issues/29.
