### PR TITLE
Add version+repo specifications to the EESSI packages in our set

### DIFF
--- a/etc/portage/sets/2020.10
+++ b/etc/portage/sets/2020.10
@@ -1,9 +1,9 @@
-app-admin/Lmod
+=app-admin/Lmod-8.4.5::eessi
 app-editors/emacs
 app-editors/vim
 dev-util/strace
 media-fonts/dejavu
 media-fonts/liberation-fonts
-sys-apps/archspec
-sys-cluster/rdma-core
-sys-fabric/opa-psm2
+=sys-apps/archspec-0.1.1::eessi
+=sys-cluster/rdma-core-31.0::eessi
+=sys-fabric/opa-psm2-11.2.185::eessi


### PR DESCRIPTION
This should prevent that newer packages (e.g. for `rdma-core`) will be installed, if a package in our repo has a newer version in the gentoo repo.