### PR TITLE
Fix versions for Lua libraries in 2020.12 set

### DIFF
--- a/etc/portage/sets/eessi-2020.12
+++ b/etc/portage/sets/eessi-2020.12
@@ -1,7 +1,9 @@
 =app-admin/Lmod-8.4.16::eessi
 app-editors/emacs
 app-editors/vim
-=dev-lua/luafilesystem-1.8.0-r1
+=dev-lua/luafilesystem-1.8.0-r1::eessi
+dev-lua/bit32::eessi
+dev-lua/luaposix::eessi
 media-fonts/dejavu
 media-fonts/liberation-fonts
 =sys-apps/archspec-0.1.2::eessi


### PR DESCRIPTION
One last attempt to fix the CI with our 2020.12 set. This should really work... (tested in last night's Prefix Docker image). If not, I will give up and just prepare the ebuilds for the next release instead (with the new/slotted Lua).