### PR TITLE
Add package.env that passes user-defined-trusted-dirs to glibc

### DIFF
--- a/etc/portage/env/glibc-user-defined-trusted-dirs.conf
+++ b/etc/portage/env/glibc-user-defined-trusted-dirs.conf
@@ -1,0 +1,1 @@
+EXTRA_EMAKE="user-defined-trusted-dirs=/opt/eessi/lib64"

--- a/etc/portage/env/glibc-user-defined-trusted-dirs.conf
+++ b/etc/portage/env/glibc-user-defined-trusted-dirs.conf
@@ -1,1 +1,1 @@
-EXTRA_EMAKE="user-defined-trusted-dirs=/opt/eessi/lib64"
+EXTRA_EMAKE="user-defined-trusted-dirs=/opt/eessi/lib"

--- a/etc/portage/package.env
+++ b/etc/portage/package.env
@@ -1,0 +1,1 @@
+sys-libs/glibc glibc-user-defined-trusted-dirs.conf


### PR DESCRIPTION
Now we just need to make sure that it's actually used, as the bootstrap will not make use of this. So I guess we should add `glibc` to our set to make sure it gets reinstalled?

Closes #7.