### PR TITLE
CI should only push set files on pushes to master

### DIFF
--- a/.github/workflows/generate_sets.yml
+++ b/.github/workflows/generate_sets.yml
@@ -37,6 +37,7 @@ jobs:
         python  scripts/generate_set_files.py -y scripts/eessi_sets.yml -d etc/portage/sets
 
     - name: Commit added/modified package set files
+      if: ${{ github.event_name == 'pull_request' }}
       run: |
         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"

--- a/.github/workflows/generate_sets.yml
+++ b/.github/workflows/generate_sets.yml
@@ -42,7 +42,9 @@ jobs:
         git config --local user.name "github-actions[bot]"
         git add etc/portage/sets/*
         git commit -m "Add generated set files" -a || echo "No changes to commit"
+
     - name: Push changes
+      if: ${{ github.event_name == 'pull_request' }}
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
PRs don't have permission to push to the repo, so the old approach doesn't work (see #13).
I hope it does work with this fix, though `main` is a protected branch, so I'm not sure if an action is allowed to push to it at all...