### PR TITLE
Remove the conf file with the user-defined-trusted-dirs option for glibc

### DIFF
--- a/etc/portage/env/glibc-user-defined-trusted-dirs.conf
+++ b/etc/portage/env/glibc-user-defined-trusted-dirs.conf
@@ -1,1 +1,0 @@
-EXTRA_EMAKE="user-defined-trusted-dirs=/opt/eessi/lib"

--- a/etc/portage/package.env
+++ b/etc/portage/package.env
@@ -1,1 +1,0 @@
-sys-libs/glibc glibc-user-defined-trusted-dirs.conf


### PR DESCRIPTION
This is now being taken care of by the playbook, see:
https://github.com/EESSI/compatibility-layer/pull/87