### PR TITLE
Temporary fix for Lmod installation on aarch64 (and ppc64le)

### DIFF
--- a/etc/portage/package.accept_keywords
+++ b/etc/portage/package.accept_keywords
@@ -1,2 +1,5 @@
 media-fonts/dejavu ~x86-macos
 media-fonts/liberation-fonts ~amd64-linux
+sys-cluster/lmod ~amd64
+dev-lua/luaposix ~amd64
+dev-lua/lua-bit32 amd64

--- a/etc/portage/package.accept_keywords
+++ b/etc/portage/package.accept_keywords
@@ -1,5 +1,5 @@
 media-fonts/dejavu ~x86-macos
 media-fonts/liberation-fonts ~amd64-linux
+dev-lua/luaposix ~amd64-linux
+dev-lua/lua-bit32 ~amd64-linux
 sys-cluster/lmod ~amd64
-dev-lua/luaposix ~amd64
-dev-lua/lua-bit32 amd64


### PR DESCRIPTION
Temporary fix for #26 that allows us to do a new pilot installation. Can be undone when the fix in https://bugs.gentoo.org/773313 gets merged.