### PR TITLE
Remove temporary accept keywords for Lmod

### DIFF
--- a/etc/portage/package.accept_keywords
+++ b/etc/portage/package.accept_keywords
@@ -1,6 +1,3 @@
 media-fonts/dejavu ~x86-macos
 media-fonts/liberation-fonts ~amd64-linux
-dev-lua/luaposix ~amd64-linux
-dev-lua/lua-bit32 ~amd64-linux
 dev-python/semver ~amd64
-sys-cluster/lmod ~amd64


### PR DESCRIPTION
Closes #32.

Lmod and some lua dependencies have been keyworded for arm64 and ppc64, see https://bugs.gentoo.org/773313, so the change from PR #31 can be undone.