### PR TITLE
Remove accept keywords for dev-python/semver

### DIFF
--- a/etc/portage/package.accept_keywords
+++ b/etc/portage/package.accept_keywords
@@ -1,3 +1,2 @@
 media-fonts/dejavu ~x86-macos
 media-fonts/liberation-fonts ~amd64-linux
-dev-python/semver ~amd64


### PR DESCRIPTION
Closes https://github.com/EESSI/gentoo-overlay/issues/48.

Gentoo added `arm64` keywording:
https://bugs.gentoo.org/795966