### PR TITLE
remove dev-util/pkgconfig from 2021.12 set

### DIFF
--- a/scripts/eessi_sets.yml
+++ b/scripts/eessi_sets.yml
@@ -19,7 +19,7 @@ eessi_sets:
       - name: dev-python/pyyaml
       - name: dev-python/rich
       - name: dev-util/patchelf
-      - name: dev-util/pkgconfig
+      - name: dev-util/pkgconf
       - name: media-fonts/dejavu
       - name: media-fonts/liberation-fonts
       - name: sys-apps/archspec

--- a/scripts/eessi_sets.yml
+++ b/scripts/eessi_sets.yml
@@ -19,7 +19,6 @@ eessi_sets:
       - name: dev-python/pyyaml
       - name: dev-python/rich
       - name: dev-util/patchelf
-      - name: dev-util/pkgconf
       - name: media-fonts/dejavu
       - name: media-fonts/liberation-fonts
       - name: sys-apps/archspec


### PR DESCRIPTION
fix for problem that popped up when building 2021.12 compat layer (on `aarch64`):

```
emerge: there are no ebuilds to satisfy "dev-util/pkgconfig".
(dependency required by "@eessi-2021.12-linux-aarch64" [argument])
```

`dev-util/pkgconfig` was removed from Gentoo (in favor of `dev-util/pkgconf`)

We originally added `dev-util/pkgconfig` to avoid installing `pkg-config` with EasyBuild, but we had to revisit that due to problems with Bioconductor and `gnuplot` when not providing `pkg-config` in the software layer (see https://github.com/EESSI/software-layer/commit/51d48416586ad5e2b8a25a89b84dffd49f8a4ced).

So rather than switching to `dev-util/pkgconf`, we might as well remove it.