### PR TITLE
accept ~amd64 keyword for sys-cluster/lmod so it can be installed in aarch64 compat layer

### DIFF
--- a/etc/portage/package.accept_keywords
+++ b/etc/portage/package.accept_keywords
@@ -1,3 +1,4 @@
 dev-python/rich ~amd64
 media-fonts/dejavu ~x86-macos
 media-fonts/liberation-fonts ~amd64-linux
+sys-cluster/lmod ~amd64


### PR DESCRIPTION
Keyword required to install `sys-cluster/lmod` is missing for `aarch64` compat layer, this is a workaround until https://github.com/gentoo/gentoo/pull/23020 gets merged