### PR TITLE
Enable Portage test feature for archspec and ReFrame

### DIFF
--- a/etc/portage/env/test.conf
+++ b/etc/portage/env/test.conf
@@ -1,0 +1,1 @@
+FEATURES="test"

--- a/etc/portage/package.env
+++ b/etc/portage/package.env
@@ -1,0 +1,3 @@
+sys-apps/archspec test.conf
+sys-cluster/lmod test.conf
+sys-cluster/reframe test.conf

--- a/etc/portage/package.env
+++ b/etc/portage/package.env
@@ -1,3 +1,2 @@
 sys-apps/archspec test.conf
-sys-cluster/lmod test.conf
 sys-cluster/reframe test.conf


### PR DESCRIPTION
Closes https://github.com/EESSI/compatibility-layer/issues/136.

This will run the tests for these packages during the installation. At the moment it only does it for `archspec` and `ReFrame`, as most of the other ones don't have tests, or they're not configured/enabled in the ebuild, or they fail (Lmod uses a hardcoded path to `/bin/tcsh`). We can extend the list later on.