### PR TITLE
Enable Portage tests for sys-cluster/lmod

### DIFF
--- a/etc/portage/package.env
+++ b/etc/portage/package.env
@@ -1,2 +1,3 @@
 sys-apps/archspec test.conf
+sys-cluster/lmod test.conf
 sys-cluster/reframe test.conf


### PR DESCRIPTION
Closes #68. Also see https://bugs.gentoo.org/827152.