### PR TITLE
add sys-devel/gcc-9.4.0 to 2021.12 sets

### DIFF
--- a/scripts/eessi_sets.yml
+++ b/scripts/eessi_sets.yml
@@ -31,8 +31,10 @@ eessi_sets:
           - macos-aarch64
           - macos-x86_64
       - name: sys-cluster/reframe
-        overlay: eessi
         version: 3.9.1
+        overlay: eessi
+      - name: sys-devel/gcc
+        version: 9.4.0
       - name: sys-fabric/opa-psm2
         version: 11.2.205
         overlay: eessi


### PR DESCRIPTION
motivated by problems with building `GCCcore-9.3.0.eb` described in https://github.com/EESSI/software-layer/issues/151