### PR TITLE
remove gcc 9.4 from 2021.12 set

### DIFF
--- a/scripts/eessi_sets.yml
+++ b/scripts/eessi_sets.yml
@@ -33,8 +33,6 @@ eessi_sets:
       - name: sys-cluster/reframe
         version: 3.9.1
         overlay: eessi
-      - name: sys-devel/gcc
-        version: 9.4.0
       - name: sys-fabric/opa-psm2
         version: 11.2.205
         overlay: eessi


### PR DESCRIPTION
This reverts #72, because a better approach is to do the whole bootstrap with GCC 9.4, see https://github.com/EESSI/compatibility-layer/pull/140