### PR TITLE
Add numactl to 2021.12 set to bring lists of installed packages more in sync for aarch64/ppc64le and x86_64

### DIFF
--- a/scripts/eessi_sets.yml
+++ b/scripts/eessi_sets.yml
@@ -44,3 +44,4 @@ eessi_sets:
         exclude_on:
           - macos-aarch64
           - macos-x86_64
+      - name: sys-process/numactl


### PR DESCRIPTION
This is a dependency of `opa-psm2`, which only gets installed on `x86_64`. Adding `numactl` to our set will result in a more equal set of packages on all architectures.