### PR TITLE
Use Gentoo's sys-libs/pam

### DIFF
--- a/scripts/eessi_sets.yml
+++ b/scripts/eessi_sets.yml
@@ -38,8 +38,6 @@ eessi_sets:
         include_on:
           - linux-x86_64
       - name: sys-libs/pam
-        version: 1.5.2
-        overlay: eessi
         exclude_on:
           - macos-aarch64
           - macos-x86_64


### PR DESCRIPTION
We removed it from our overlay, see https://github.com/EESSI/gentoo-overlay/pull/82.