### PR TITLE
fix xz-utils checksum

### DIFF
--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Run pkgcheck
-      uses: pkgcore/pkgcheck-action@5a0413f4494d00e286fb7cf6b8388b6c4578afa4 # No releases, v1 branch
+      uses: pkgcore/pkgcheck-action@16edefb00ef1485e2eb2bfd3d93a70b198b2537f # No releases, v1 branch
       with:
-        args: 'dev-util sys-apps sys-cluster sys-fabric'
+        args: 'app-arch app-misc dev-python dev-util sys-apps sys-auth sys-cluster sys-fabric'


### PR DESCRIPTION
I was wondering why CI hadn't spotted this, but it was disabled, and also the list of subdirs had to be updated. Before I actually fix the checksum, let's check if it will catch the issue now.